### PR TITLE
Update structopt to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["{{authors}}"]
 edition = "2018"
 
 [dependencies]
-structopt = "0.2"
+structopt = "0.3"
 


### PR DESCRIPTION
I've checked that the current `main.rs` content works with the latest `structopt` v0.3.17  